### PR TITLE
Adjust signup role change confirmation text

### DIFF
--- a/views.py
+++ b/views.py
@@ -86,7 +86,7 @@ async def handle_signup(interaction: discord.Interaction, raid_id: int, role_nam
         promotions = await sync_roster(interaction.client, raid)
         await announce_promotions(interaction.client, raid, promotions)
         await interaction.response.send_message(
-            f"Ваша роль обновлена на **{role_name}**.", ephemeral=True
+            f"Вы записались как **{role_name}** (обновлено).", ephemeral=True
         )
         return
 


### PR DESCRIPTION
## Summary
- ensure role change confirmations use the same phrasing as new signups so users receive consistent feedback

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc881dc4b08322a2c6c03164036e54