### PR TITLE
Silence audioop deprecation warning during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,20 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
-import pytest
-
 import sys
+import warnings
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+warnings.filterwarnings(
+    "ignore",
+    message="'audioop' is deprecated and slated for removal in Python 3.13",
+    category=DeprecationWarning,
+)
 
 try:  # pragma: no cover - executed only when discord is unavailable
     import discord  # type: ignore


### PR DESCRIPTION
## Summary
- silence the audioop DeprecationWarning emitted by discord when running pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc905679f48322948c6b4b829b403f